### PR TITLE
Ong and RCG Rhetoric for rerum.io

### DIFF
--- a/app/about/about.html
+++ b/app/about/about.html
@@ -42,9 +42,9 @@
     </p>
     <address class="one-half columns">
         Research Computing Group<br>
+        DuBourg Hall Room 443<br>
         221 N Grand Blvd,<br>
         St. Louis, MO 63103 USA<br>
-        DuBourg Hall, Room 443
     </address>
 </div>
    <p>

--- a/app/about/about.html
+++ b/app/about/about.html
@@ -43,7 +43,7 @@
     <address class="one-half columns">
         Research Computing Group<br>
         221 N Grand Blvd,<br>
-        St. Louis, MO 63103
+        St. Louis, MO 63103<br>
         Room 443
     </address>
 </div>

--- a/app/about/about.html
+++ b/app/about/about.html
@@ -1,8 +1,8 @@
 <div class="container">
     <p>RERUM was born in the <a href="https://ongcdh.org">
         Walter J. Ong, <small>S.J.</small> Center for Digital Humanities</a> at Saint Louis
-        University and is funded and maintained by their technical staff. 
-        Patrs of this site are designed for developers and programmers while 
+        University and is funded and maintained by the <a href="https://www.slu.edu/research/faculty-resources/research-computing.php">Research Computing Group</a>. 
+        Parts of this site are designed for developers and programmers while 
         others may be easy to share with researchers and investigators 
         who need a good place to put some data and insist on openness.</p>
     <p>Our goal is to raise the quality of and participation in open academic
@@ -16,10 +16,13 @@
     <h4>Contact</h4>
     <div class="row">
         <p class="columns">
-            OngCDH is responsible for RERUM and you can usually reach us during Central Time
+            <!--
+            RCG is responsible for RERUM and you can usually reach us during Central Time
             (UTC{{tzOffset}}) business hours at
+            -->
             <a href="mailto:digitalhumanities@slu.edu">digitalhumanities@slu.edu</a>, 
-            <a href="https://join.slack.com/t/ongcdh/shared_invite/zt-r1gzdf53-7H4Nqst_ktskCJIl~m4ZLw">Slack</a>, or follow our projects
+            <!-- <a href="https://join.slack.com/t/ongcdh/shared_invite/zt-r1gzdf53-7H4Nqst_ktskCJIl~m4ZLw">Slack</a> -->
+            or follow our projects
             <a href="https://github.com/CenterForDigitalHumanities">
                 <i class="fa fa-github"></i>
                 online</a>.
@@ -38,9 +41,10 @@
         Duo, Slack, Jitsi, Imo, Twiddla or whatever flavor you prefer. Visit us in person:
     </p>
     <address class="one-half columns">
-        Walter J. Ong <small>S.J.</small> Center for Digital Humanities<br>
-        One North Grand, <br>
-        St. Louis, MO 63108 USA
+        Research Computing Group<br>
+        221 N Grand Blvd,<br>
+        St. Louis, MO 63103
+        Room 443
     </address>
 </div>
    <p>

--- a/app/about/about.html
+++ b/app/about/about.html
@@ -43,8 +43,8 @@
     <address class="one-half columns">
         Research Computing Group<br>
         221 N Grand Blvd,<br>
-        St. Louis, MO 63103<br>
-        Room 443
+        St. Louis, MO 63103 USA<br>
+        DuBourg Hall, Room 443
     </address>
 </div>
    <p>

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ reconditorium eximium rerum universalium mutabiliumque
 
 RERUM is a product of the Center for Digital Humanities at Saint Louis
         University and is (currently) completely funded and maintained by the
-        fine folks on their retirement plan. This site is meant to be used by
+        fine folks in the Researching Computing Group. This site is meant to be used by
         developers and programmers who need a good place to put some data and
         prefer that it be a public place that is not too expensive.
         
@@ -22,8 +22,8 @@ Originally conceived as a "IIIF Store" (iiif.io), RERUM is designed to act as an
 open node for annotation and references that need to be made in an interoperable
 world of scholarly assertions.
 
-This project is not only access to the existing instance, created by the
-Center for Digital Humanities and hosted by Saint Louis University, but
+This project is not only access to the existing instance, mainted and hosted by
+the Research Computing Group at Saint Louis University, but
 also the complete cut list for making your own. However useful this may be for private
 projects, applications in development, or because of funding requirements, we
 hope that your machine enjoys talking to others and releases its gnats of

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ Originally conceived as a "IIIF Store" (iiif.io), RERUM is designed to act as an
 open node for annotation and references that need to be made in an interoperable
 world of scholarly assertions.
 
-This project is not only access to the existing instance, mainted and hosted by
+This project is not only access to the existing instance, maintained and hosted by
 the Research Computing Group at Saint Louis University, but
 also the complete cut list for making your own. However useful this may be for private
 projects, applications in development, or because of funding requirements, we


### PR DESCRIPTION
Swap out or combine the mentions of Digital Humanities and Research Computing Group in page text.