### PR TITLE
Enable text selection

### DIFF
--- a/app/tools/crop-page/crop-page.css
+++ b/app/tools/crop-page/crop-page.css
@@ -9,11 +9,6 @@ and open the template in the editor.
 */
 
 /* Parsing */
-body {
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    user-select: none;
-}
 .cropButtons {
     position:fixed;
     top:5px;

--- a/app/tools/parse-rect/parse-rect.css
+++ b/app/tools/parse-rect/parse-rect.css
@@ -18,11 +18,6 @@ and open the template in the editor.
     height: 80vh;
     overflow: hidden;
 }
-body {
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    user-select: none;
-}
 .parseButtons {
     position:fixed;
     top:5px;


### PR DESCRIPTION
text selection is currently disabled on the site because it was turned off in these two tools, even though it was set to enabled in the root css file. 